### PR TITLE
Automatically determine pkg and repo URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+.idea/
 .idea/*
+vendor/
+
 canonical-gen

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,0 +1,7 @@
+memo = "5fe270d00830aa7966107e6e75f53d1ab1333dcdd3b279440d8db58f9f7bd1a8"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/tools"
+  packages = ["go/vcs"]
+  revision = "81478017b604f98ba7a7300ddf703b12b119c49c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,56 @@
+
+## Gopkg.toml example (these lines may be deleted)
+
+## "required" lists a set of packages (not projects) that must be included in
+## Gopkg.lock. This list is merged with the set of packages imported by the current
+## project. Use it when your project needs a package it doesn't explicitly import -
+## including "main" packages.
+# required = ["github.com/user/thing/cmd/thing"]
+
+## "ignored" lists a set of packages (not projects) that are ignored when
+## dep statically analyzes source code. Ignored packages can be in this project,
+## or in a dependency.
+# ignored = ["github.com/user/project/badpkg"]
+
+## Dependencies define constraints on dependent projects. They are respected by
+## dep whether coming from the Gopkg.toml of the current project or a dependency.
+# [[dependencies]]
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Recommended: the version constraint to enforce for the project.
+## Only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: an alternate location (URL or import path) for the project's source.
+# source = "https://github.com/myfork/package.git"
+
+## Overrides have the same structure as [[dependencies]], but supercede all
+## [[dependencies]] declarations from all projects. Only the current project's
+## [[overrides]] are applied.
+##
+## Overrides are a sledgehammer. Use them only as a last resort.
+# [[overrides]]
+## Required: the root import path of the project being constrained.
+# name = "github.com/user/project"
+#
+## Optional: specifying a version constraint override will cause all other
+## constraints on this project to be ignored; only the overriden constraint
+## need be satisfied.
+## Again, only one of "branch", "version" or "revision" can be specified.
+# version = "1.0.0"
+# branch = "master"
+# revision = "abc123"
+#
+## Optional: specifying an alternate source location as an override will
+## enforce that the alternate location is used for that project, regardless of
+## what source location any dependent projects specify.
+# source = "https://github.com/myfork/package.git"
+
+
+
+[[dependencies]]
+  branch = "master"
+  name = "golang.org/x/tools"

--- a/main.go
+++ b/main.go
@@ -4,17 +4,20 @@ import (
 	"flag"
 	"os"
 	"text/template"
+	"strings"
+
+	"golang.org/x/tools/go/vcs"
 )
 
-var html string = `
-<html>
+var html string = `<html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 		<meta name="go-import" content="{{.pkg}} {{.type}} {{.repo}}">
 		<meta http-equiv="refresh" content="0; url={{.repo}}">
+		<title>{{.pkg}}</title>
 	</head>
 	<body>
-		Nothing to see here; <a href="{{.repo}}">move along</a>.
+		Click <a href="{{.repo}}">here</a> to visit actual repository
 	</body>
 </html>
 `
@@ -24,6 +27,16 @@ func main() {
 	repo := flag.String("repoUrl", "", "repository url")
 	repoType := flag.String("repoType", "git", "repository type, git is the default")
 	flag.Parse()
+
+	if *pkg == "" {
+		dir, _ := os.Getwd()
+		*pkg = strings.Split(dir, "src/")[1]
+	}
+
+	if *repo == "" {
+		repoRoot, _ := vcs.RepoRootForImportPath(*pkg, false)
+		*repo = repoRoot.Repo
+	}
 
 	t, _ := template.New("html").Parse(html)
 


### PR DESCRIPTION
Run the command at the root of a go package directory, and it will work out the import path of the package and the repository's URL